### PR TITLE
Chang variable to empty string if it's None

### DIFF
--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -34,6 +34,8 @@ def _get_or_create_hostfile():
     does not exist.
     '''
     hfn = __get_hosts_filename()
+    if hfn is None:
+        hfn = ''
     if not os.path.exists(hfn):
         salt.utils.fopen(hfn, 'w').close()
     return hfn


### PR DESCRIPTION
To prevent a stacktrace when using os.path.exists
