### PR TITLE
Fix remaining failing tests for merge forward

### DIFF
--- a/tests/unit/modules/win_repo_test.py
+++ b/tests/unit/modules/win_repo_test.py
@@ -24,6 +24,7 @@ ensure_in_syspath('../../')
 from salt.modules import win_repo
 
 win_repo.__opts__ = {}
+win_repo.__salt__ = {}
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -31,6 +32,8 @@ class WinRepoTestCase(TestCase):
     '''
         Test cases for salt.modules.win_repo
     '''
+
+    @patch('salt.loader.render', MagicMock(return_valu=''))
     def test_genrepo(self):
         '''
             Test to generate win_repo_cachefile

--- a/tests/unit/states/saltmod_test.py
+++ b/tests/unit/states/saltmod_test.py
@@ -80,10 +80,10 @@ class SaltmodTestCase(TestCase):
         minion via salt or salt-ssh
         '''
         name = 'state'
-        tgt = 'minion1'
+        tgt = 'larry'
 
         comt = ('Function state will be executed'
-                ' on target minion1 as test=False')
+                ' on target {0} as test=False'.format(tgt))
 
         ret = {'name': name,
                'changes': {},
@@ -93,10 +93,14 @@ class SaltmodTestCase(TestCase):
         with patch.dict(saltmod.__opts__, {'test': True}):
             self.assertDictEqual(saltmod.function(name, tgt), ret)
 
-        ret.update({'comment': 'Function ran successfully.', 'result': True})
+        ret.update({'result': True,
+                    'changes': {'out': 'highstate', 'ret': {tgt: ''}},
+                    'comment': 'Function ran successfully.'
+                              ' Function state ran on {0}.'.format(tgt)})
         with patch.dict(saltmod.__opts__, {'test': False}):
-            mock = MagicMock(return_value={'minion': {'retcode': 0, 'ret': True}})
-            with patch.dict(saltmod.__salt__, {'saltutil.cmd': mock}):
+            mock_ret = {'larry': {'ret': '', 'retcode': 0, 'failed': False}}
+            mock_cmd = MagicMock(return_value=mock_ret)
+            with patch.dict(saltmod.__salt__, {'saltutil.cmd': mock_cmd}):
                 self.assertDictEqual(saltmod.function(name, tgt), ret)
 
     # 'wait_for_event' function tests: 1


### PR DESCRIPTION
Fixes:
- unit.states.saltmod_test.SaltmodTestCase.test_function
- unit.modules.win_repo_test.WinRepoTestCase.test_genrepo
